### PR TITLE
Add cancelled status for command

### DIFF
--- a/protocol/mmc/info.proto
+++ b/protocol/mmc/info.proto
@@ -75,6 +75,8 @@ message Response {
       STATUS_FAILED = 3;
       /// Command is waiting to be executed by the server.
       STATUS_QUEUED = 4;
+      /// Command is cancelled by the user
+      STATUS_CANCELLED = 5;
     }
     enum ErrorKind {
       ERROR_KIND_UNSPECIFIED = 0;

--- a/src/proto/mmc/info.pb.zig
+++ b/src/proto/mmc/info.pb.zig
@@ -182,6 +182,7 @@ pub const Response = struct {
             STATUS_COMPLETED = 2,
             STATUS_FAILED = 3,
             STATUS_QUEUED = 4,
+            STATUS_CANCELLED = 5,
             _,
         };
 


### PR DESCRIPTION
I forgot to add this. It fails the zig test for the server.

I am going to re-release the api.